### PR TITLE
Integrate with kudaf

### DIFF
--- a/deploy/prod/env.yaml
+++ b/deploy/prod/env.yaml
@@ -21,3 +21,8 @@ spec:
                 secretKeyRef:
                   name: commonurl-prod
                   key: FDK_BASE_URI
+            - name: CORS_ORIGIN_PATTERNS
+              valueFrom:
+                secretKeyRef:
+                  name: access-request-api
+                  key: CORS_ORIGIN_PATTERNS

--- a/deploy/staging/env.yaml
+++ b/deploy/staging/env.yaml
@@ -21,3 +21,8 @@ spec:
                 secretKeyRef:
                   name: commonurl-staging
                   key: FDK_BASE_URI
+            - name: CORS_ORIGIN_PATTERNS
+              valueFrom:
+                secretKeyRef:
+                  name: access-request-api
+                  key: CORS_ORIGIN_PATTERNS

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
 
         <dependency>
             <groupId>net.logstash.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
 
         <dependency>
             <groupId>net.logstash.logback</groupId>

--- a/src/main/kotlin/no/digdir/accessrequestapi/client/KudafClient.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/client/KudafClient.kt
@@ -1,0 +1,28 @@
+package no.digdir.accessrequestapi.client
+
+import no.digdir.accessrequestapi.configuration.KudafUrls
+import no.digdir.accessrequestapi.model.ShoppingCart
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+
+@Component
+class KudafClient(
+    kudafUrls: KudafUrls,
+) {
+    val webClient = WebClient.create(kudafUrls.soknadApi)
+
+    fun getRedirectUrl(cart: ShoppingCart): String? =
+        webClient
+            .post()
+            .uri("/cart")
+            .bodyValue(cart)
+            .retrieve()
+            .bodyToMono<KudafAccessRequestResponse>()
+            .block()
+            ?.redirectUrl
+}
+
+data class KudafAccessRequestResponse(
+    val redirectUrl: String,
+)

--- a/src/main/kotlin/no/digdir/accessrequestapi/configuration/CorsProperties.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/configuration/CorsProperties.kt
@@ -1,0 +1,8 @@
+package no.digdir.accessrequestapi.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("application.cors")
+class CorsProperties(
+    val originPatterns: Array<String>,
+)

--- a/src/main/kotlin/no/digdir/accessrequestapi/configuration/KudafUrls.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/configuration/KudafUrls.kt
@@ -1,0 +1,8 @@
+package no.digdir.accessrequestapi.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("url.kudaf")
+data class KudafUrls(
+    val soknadApi: String,
+)

--- a/src/main/kotlin/no/digdir/accessrequestapi/configuration/SecurityConfig.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/configuration/SecurityConfig.kt
@@ -1,0 +1,34 @@
+package no.digdir.accessrequestapi.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
+
+@Configuration
+open class SecurityConfig(
+    val corsProperties: CorsProperties,
+) {
+    @Bean
+    open fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .cors { corsConfigurer ->
+                corsConfigurer.configurationSource {
+                    CorsConfiguration().also {
+                        it.allowCredentials = false
+                        it.allowedHeaders = listOf("*")
+                        it.maxAge = 3600L
+                        it.allowedOriginPatterns = corsProperties.originPatterns.toList()
+                        it.allowedMethods = listOf("GET", "POST", "OPTIONS")
+                    }
+                }
+            }.csrf {
+                it.disable()
+            }.sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+        return http.build()
+    }
+}

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
@@ -7,6 +7,7 @@ import no.digdir.accessrequestapi.configuration.FdkUrls
 import no.digdir.accessrequestapi.model.DatasetLanguage
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,6 +20,7 @@ import java.util.UUID
 @Tag(name = "Access request")
 @RestController
 @RequestMapping(value = ["/access-request"], produces = ["application/json"])
+@CrossOrigin
 class AccessRequestController(
     val fdkUrls: FdkUrls,
     val felleskatalogClient: FelleskatalogClient,

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
@@ -1,5 +1,6 @@
 package no.digdir.accessrequestapi.controller
 
+import io.swagger.v3.oas.annotations.tags.Tag
 import no.digdir.accessrequestapi.client.FelleskatalogClient
 import no.digdir.accessrequestapi.client.KudafClient
 import no.digdir.accessrequestapi.configuration.FdkUrls
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import java.util.UUID
 
+@Tag(name = "Access request")
 @RestController
 @RequestMapping(value = ["/access-request"], produces = ["application/json"])
 class AccessRequestController(

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
@@ -7,7 +7,6 @@ import no.digdir.accessrequestapi.configuration.FdkUrls
 import no.digdir.accessrequestapi.model.DatasetLanguage
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -20,7 +19,6 @@ import java.util.UUID
 @Tag(name = "Access request")
 @RestController
 @RequestMapping(value = ["/access-request"], produces = ["application/json"])
-@CrossOrigin
 class AccessRequestController(
     val fdkUrls: FdkUrls,
     val felleskatalogClient: FelleskatalogClient,

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/AccessRequestController.kt
@@ -8,8 +8,8 @@ import no.digdir.accessrequestapi.model.DatasetLanguage
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -28,26 +28,19 @@ class AccessRequestController(
     @ExceptionHandler(WebClientResponseException.NotFound::class)
     fun handleNotFound() {}
 
-    @GetMapping("/{language}/{type}/{id}")
-    fun getApplicationUrl(
+    @PostMapping("/{language}/{type}/{id}")
+    fun createKudafApplication(
         @PathVariable language: DatasetLanguage,
         @PathVariable type: String,
         @PathVariable id: UUID,
     ): ResponseEntity<String> {
-        val metadata =
-            felleskatalogClient.getMetadata(type, id) ?: return ResponseEntity.notFound().build()
+        val metadata = felleskatalogClient.getMetadata(type, id) ?: return ResponseEntity.notFound().build()
 
-        return when (metadata.accessRequestUrl) {
-            null,
-            "soknad.kudaf.no",
-            -> {
-                val shoppingCart = metadata.toShoppingCart(resourceId = "${fdkUrls.frontend}/$type/$id", language = language)
-                val redirectUrl = kudafClient.getRedirectUrl(shoppingCart) ?: return ResponseEntity.notFound().build()
+        val shoppingCart =
+            metadata.toShoppingCart(resourceId = "${fdkUrls.frontend}/$type/$id", language = language)
 
-                ResponseEntity.ok(redirectUrl)
-            }
+        val redirectUrl = kudafClient.getRedirectUrl(shoppingCart) ?: return ResponseEntity.notFound().build()
 
-            else -> ResponseEntity.ok(metadata.accessRequestUrl)
-        }
+        return ResponseEntity.ok(redirectUrl)
     }
 }

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
@@ -1,5 +1,6 @@
 package no.digdir.accessrequestapi.controller
 
+import io.swagger.v3.oas.annotations.tags.Tag
 import no.digdir.accessrequestapi.client.FelleskatalogClient
 import no.digdir.accessrequestapi.model.DatasetLanguage
 import no.digdir.accessrequestapi.model.DatasetMetadata
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import java.util.UUID
 
+@Tag(name = "DataDef resolver")
 @RestController
 @RequestMapping(value = ["/datadef-resolver"], produces = ["application/json"])
 class KudafResolverController(

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
@@ -1,0 +1,59 @@
+package no.digdir.accessrequestapi.controller
+
+import no.digdir.accessrequestapi.client.FelleskatalogClient
+import no.digdir.accessrequestapi.model.DatasetLanguage
+import no.digdir.accessrequestapi.model.DatasetMetadata
+import no.digdir.accessrequestapi.model.ShoppingCart
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.util.UUID
+
+@RestController
+@RequestMapping(value = ["/datadef-resolver"], produces = ["application/json"])
+class KudafResolverController(
+    val felleskatalogClient: FelleskatalogClient,
+) {
+    @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Resource not found")
+    @ExceptionHandler(WebClientResponseException.NotFound::class)
+    fun handleNotFound() {}
+
+    @PostMapping("/{language}")
+    fun resolveDataDef(
+        @PathVariable language: DatasetLanguage,
+        @RequestBody dataDef: ShoppingCart.DataDef,
+    ): ResponseEntity<ResolveDataDefResponse> {
+        val uriReversed =
+            java.net
+                .URI(dataDef.resourceId)
+                .path
+                .split("/")
+                .filter { it.isNotEmpty() }
+                .asReversed()
+
+        val resourceId: UUID = UUID.fromString(uriReversed[0])
+        val resourceType = uriReversed[1]
+
+        val metadata =
+            felleskatalogClient.getMetadata(resourceType, resourceId) ?: return ResponseEntity.notFound().build()
+
+        return ResponseEntity.ok(ResolveDataDefResponse(metadata, language))
+    }
+}
+
+data class ResolveDataDefResponse(
+    val title: String?,
+    val description: String?,
+) {
+    constructor(metadata: DatasetMetadata, language: DatasetLanguage) : this(
+        title = metadata.title.get(language),
+        description = metadata.description?.get(language),
+    )
+}

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
@@ -7,6 +7,7 @@ import no.digdir.accessrequestapi.model.DatasetMetadata
 import no.digdir.accessrequestapi.model.ShoppingCart
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,6 +21,7 @@ import java.util.UUID
 @Tag(name = "DataDef resolver")
 @RestController
 @RequestMapping(value = ["/datadef-resolver"], produces = ["application/json"])
+@CrossOrigin
 class KudafResolverController(
     val felleskatalogClient: FelleskatalogClient,
 ) {

--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
@@ -7,7 +7,6 @@ import no.digdir.accessrequestapi.model.DatasetMetadata
 import no.digdir.accessrequestapi.model.ShoppingCart
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -21,7 +20,6 @@ import java.util.UUID
 @Tag(name = "DataDef resolver")
 @RestController
 @RequestMapping(value = ["/datadef-resolver"], produces = ["application/json"])
-@CrossOrigin
 class KudafResolverController(
     val felleskatalogClient: FelleskatalogClient,
 ) {

--- a/src/main/kotlin/no/digdir/accessrequestapi/model/DatasetMetadata.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/model/DatasetMetadata.kt
@@ -1,6 +1,7 @@
 package no.digdir.accessrequestapi.model
 
 data class DatasetMetadata(
+    val accessRequestUrl: String?,
     val contactPoint: List<ContactPoint>,
     val title: LocalizedStrings,
     val publisher: Publisher,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,8 +18,11 @@ management:
         include: health, info
 
 url:
-  fellesdatakatalog.api: ${RESOURCE_SERVICE_URI}
-  fellesdatakatalog.frontend: ${FDK_URI}
+  fellesdatakatalog:
+    api: ${RESOURCE_SERVICE_URI}
+    frontend: ${FDK_URI}
+  kudaf:
+    soknadApi: https://frontend-soknad-api.paas2.uninett.no
 
 ---
 spring:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,10 @@ url:
   kudaf:
     soknadApi: https://frontend-soknad-api.paas2.uninett.no
 
+application:
+  cors:
+    originPatterns: ${CORS_ORIGIN_PATTERNS}
+
 ---
 spring:
   config.activate.on-profile: dev
@@ -34,6 +38,10 @@ logging:
 url:
   fellesdatakatalog.api: https://resource.api.staging.fellesdatakatalog.digdir.no
   fellesdatakatalog.frontend: https://staging.fellesdatakatalog.digdir.no
+
+application:
+  cors:
+    originPatterns: localhost:3001
 
 ---
 spring:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,10 +24,6 @@ url:
   kudaf:
     soknadApi: https://frontend-soknad-api.paas2.uninett.no
 
-
-springdoc:
-  swagger-ui:
-    path: /
 ---
 spring:
   config.activate.on-profile: dev

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,10 @@ url:
   kudaf:
     soknadApi: https://frontend-soknad-api.paas2.uninett.no
 
+
+springdoc:
+  swagger-ui:
+    path: /
 ---
 spring:
   config.activate.on-profile: dev


### PR DESCRIPTION
Etter prat med Kudaf kom vi fram til at de er klare for at vi skal begynne å integrere mot dem. Tanken er at vi sender en handleliste til dem og at de returnerer med en url som fører til en søknad hos dem. I tillegg så trenger de et endepunkt der de kan få litt informasjon om datasettet som de kan vise til søkeren. Flyten er beskrevet [her](https://app.mural.co/t/entur7578/m/entur7578/1727254267103/76e888a39214a4a312c34cef1bac20cf98bc7196?sender=u58d86e35f0f2b4a4589e0894).

Kudaf har en swaggerside som beskriver endepunktet [her](https://frontend-soknad-api.paas2.uninett.no/swagger#/Cart/post_cart).
