### PR TITLE
Legg til hint om hvem som kan søke

### DIFF
--- a/src/main/kotlin/no/digdir/accessrequestapi/model/DatasetMetadata.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/model/DatasetMetadata.kt
@@ -1,5 +1,13 @@
 package no.digdir.accessrequestapi.model
 
+val HARD_CODED_RESOURCE_ID_IS_ORG_ONLY = listOf(
+    // https://staging.fellesdatakatalog.digdir.no/data-services/ecdbd6d4-7026-3731-bd8e-2f15e26221a2
+    "ecdbd6d4-7026-3731-bd8e-2f15e26221a2",
+
+    // https://data.norge.no/data-services/031f7cea-4920-3cd4-8333-7f8992904aa5
+    "031f7cea-4920-3cd4-8333-7f8992904aa5"
+)
+
 data class DatasetMetadata(
     val accessRequestUrl: String?,
     val contactPoint: List<ContactPoint>,
@@ -44,6 +52,7 @@ data class DatasetMetadata(
         ShoppingCart(
             orgnr = publisher.id,
             hintIsPublic = accessRights?.code == AccessRight.PUBLIC,
+            hintIsOrg = resourceId in HARD_CODED_RESOURCE_ID_IS_ORG_ONLY,
             dataDef =
                 ShoppingCart.DataDef(
                     identifier = identifier?.firstOrNull(),

--- a/src/main/kotlin/no/digdir/accessrequestapi/model/ShoppingCart.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/model/ShoppingCart.kt
@@ -4,6 +4,7 @@ data class ShoppingCart(
     val orgnr: String,
     val language: DatasetLanguage,
     val hintIsPublic: Boolean,
+    val hintIsOrg: Boolean,
     val dataDef: DataDef,
 ) {
     val system: String = "datanorge"


### PR DESCRIPTION
Gjør så vi sender et hint til Kudaf dersom kun organisasjoner kan søke. Hardkoder det nå i første omgang
til https://github.com/Informasjonsforvaltning/applicationdcat-ap-no/issues/2 er på plass