### PR TITLE
Legg til id for dataressursen i resolveren

### DIFF
--- a/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
+++ b/src/main/kotlin/no/digdir/accessrequestapi/controller/KudafResolverController.kt
@@ -57,12 +57,14 @@ class KudafResolverController(
 }
 
 data class ResolveDataDefResponse(
+    val dataResourceId: UUID,
     val title: String?,
     val description: String?,
     val urlToResource: String?,
     val hintIsPrePublicationData: Boolean,
 ) {
     constructor(metadata: DataResourceMetadata, language: DatasetLanguage, urlToResource: String?) : this(
+        dataResourceId = metadata.id,
         title = metadata.title.get(language),
         description = metadata.description?.get(language),
         urlToResource = urlToResource,


### PR DESCRIPTION
Ref [slacktråd](https://entur.slack.com/archives/C05TE7H2BEG/p1736950766779399). Kudaf trenger en id for å kunne skille mellom dataressurser. Legger det til i Resolveren.